### PR TITLE
Fix error in example of README.md

### DIFF
--- a/ADCDifferentialPi/README.md
+++ b/ADCDifferentialPi/README.md
@@ -68,7 +68,7 @@ Usage
 
 To use the Delta-Sigma library in your code you must first import the library:
 ```
-from ABE_DeltaSigmaPi import DeltaSigma
+from ABE_ADCDifferentialPi import ADCDifferentialPi
 ```
 Now import the helper class
 ```


### PR DESCRIPTION
There is a reference to DeltaSigma, not to ADCDifferentialPi.