### PR TITLE
docs(missing function argument in readme)

### DIFF
--- a/RTCPi/README.md
+++ b/RTCPi/README.md
@@ -77,7 +77,7 @@ Next you must initialise the RTC object with the smbus object using the helpers:
 ```
 i2c_helper = ABEHelpers()
 bus = i2c_helper.get_smbus()
-rtc = RTC()
+rtc = RTC(bus)
 ```
 Set the current time in ISO 8601 format:
 ```


### PR DESCRIPTION
Adds the missing smbus argument to the RTC constructor in the documentation.